### PR TITLE
[DEV-9107] allow projects with rails up to version 5.2.8

### DIFF
--- a/onesie.gemspec
+++ b/onesie.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec',       '~> 2.5'
   spec.add_development_dependency 'sqlite3',             '~> 1.3.13'
 
-  spec.add_runtime_dependency 'activerecord', '~> 4.2.11.3'
+  spec.add_runtime_dependency 'activerecord', '>= 4.2.11.3', '<= 5.2.8'
   spec.add_runtime_dependency 'colorize',     '~> 0.8.1'
-  spec.add_runtime_dependency 'railties',     '~> 4.2.11.3'
+  spec.add_runtime_dependency 'railties',     '>= 4.2.11.3', '<= 5.2.8'
 end


### PR DESCRIPTION
https://benchprep.atlassian.net/browse/DEV-9107

Currently this gem only supports rails version `4.2.11.3`. This PR will allow any rails project from `4.2.11.3` through `5.2.8` inclusive to use this gem.