### PR TITLE
DACI-50: Allow Rails 6.0 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `.DS_Store` to `.gitignore`
 - Added support for Rails version 5.2.8.1 and lower
+- Added support for Rails version 6.0.0 and lower
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gem_push=no rake release
 
 ```bash
 gem push --key github \
---host https://rubygems.pkg.github.com/timlkelly \
+--host https://rubygems.pkg.github.com/watermelonexpress \
 pkg/onesie-0.2.0.gem
 ```
 

--- a/onesie.gemspec
+++ b/onesie.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec',       '~> 2.5'
   spec.add_development_dependency 'sqlite3',             '~> 1.3.13'
 
-  spec.add_runtime_dependency 'activerecord', '>= 4.2.11.3', '<= 5.2.8.1'
+  spec.add_runtime_dependency 'activerecord', '>= 4.2.11.3', '<= 6.0.0'
   spec.add_runtime_dependency 'colorize',     '~> 0.8.1'
-  spec.add_runtime_dependency 'railties',     '>= 4.2.11.3', '<= 5.2.8.1'
+  spec.add_runtime_dependency 'railties',     '>= 4.2.11.3', '<= 6.0.0'
 end


### PR DESCRIPTION
See ticket [here](https://benchprep.atlassian.net/browse/DACI-50).

Allow use of Rails 6.0.0 or below.
Part of an investigation on using RailsNext to upgrade v2 to Rails 6.0.

***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- [x] The changes are reflected in the CHANGELOG in the unreleased section
- [x] Reference the related issue if one exists, `Fix #[issue number]`
