### PR TITLE
Add support for gem consumer custom templates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,10 +29,10 @@ Lint:
 
 Metrics/BlockLength:
   Exclude:
-    - '**/*.gemspec'
-    - '**/*.rake'
-    - 'Rakefile'
-    - 'spec/**/*.rb'
+    - "**/*.gemspec"
+    - "**/*.rake"
+    - "Rakefile"
+    - "spec/**/*.rb"
 
 RSpec:
   Language:
@@ -48,4 +48,8 @@ RSpec/NestedGroups:
 
 Style/BlockDelimiters:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - lib/generators/onesie/templates/template.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `.DS_Store` to `.gitignore`
 - Added support for Rails > 5
+- Added support for custom templates
 
 ### Changed
 

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -39,7 +39,7 @@ bundle exec rails generate onesie:task MyTask high # creates a high priority tas
 
 #### API
 ```bash
-rake onesie:new[name,priority]         # Generates a new Onesie Task
+rake onesie:new[name,priority,template]         # Generates a new Onesie Task
 ```
 
 #### Examples
@@ -47,6 +47,7 @@ rake onesie:new[name,priority]         # Generates a new Onesie Task
 ```bash
 bundle exec rake onesie:new['MyTask']        # creates a normal priority task
 bundle exec rake onesie:new['MyTask','high'] # creates a high priority task
+bundle exec rake onesie:new['MyTask','high','SampleTemplate'] # creates a high priority task using 'SampleTemplate'
 ```
 
 ## Write your Onesie Task

--- a/lib/generators/onesie/task_generator.rb
+++ b/lib/generators/onesie/task_generator.rb
@@ -10,6 +10,7 @@ module Onesie
       source_root File.expand_path('./templates', __dir__)
 
       TEMPLATE_FILENAME = 'task.rb'
+      DEFAULT_TEMPLATE = '# Write your Onesie Task here'
 
       def create_task
         template(TEMPLATE_FILENAME, filename, class_name: class_name)
@@ -21,14 +22,35 @@ module Onesie
         "#{Onesie::Manager.tasks_path}/#{task_version}_#{file_name}#{task_priority}.rb"
       end
 
-      def task_priority
-        return unless args[0]
+      def run_contents
+        read_template || DEFAULT_TEMPLATE
+      end
 
-        ".#{args[0]}"
+      def read_template
+        $stderr.puts task_template
+        task_template ? File.read(custom_template_path) : nil
+      end
+
+      def custom_template_path
+        Rails.root.join('onesie', 'templates', "#{task_template}.rb")
+      end
+
+      def task_priority
+        return unless priority
+
+        ".#{priority}"
       end
 
       def task_version
         Time.now.utc.strftime('%Y%m%d%H%M%S')
+      end
+
+      def priority
+        args[0]
+      end
+
+      def task_template
+        args[1]
       end
     end
   end

--- a/lib/generators/onesie/task_generator.rb
+++ b/lib/generators/onesie/task_generator.rb
@@ -31,7 +31,7 @@ module Onesie
       end
 
       def custom_template_path
-        Rails.root.join('onesie', 'templates', "#{task_template}.rb")
+        Rails.root.join('onesie', 'templates', "#{task_template.underscore}.rb")
       end
 
       def task_priority

--- a/lib/generators/onesie/task_generator.rb
+++ b/lib/generators/onesie/task_generator.rb
@@ -27,8 +27,7 @@ module Onesie
       end
 
       def read_template
-        $stderr.puts task_template
-        task_template ? File.read(custom_template_path) : nil
+        task_template ? Onesie::TemplateReader.read_template(custom_template_path) : nil
       end
 
       def custom_template_path

--- a/lib/generators/onesie/template_generator.rb
+++ b/lib/generators/onesie/template_generator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails/generators/named_base'
+
+module Onesie
+  module Generators
+    # Generates a new Onesie template
+    class TemplateGenerator < Rails::Generators::NamedBase
+      desc 'Generate a new Onesie template'
+      source_root File.expand_path('./templates', __dir__)
+
+      TEMPLATE_FILENAME = 'template.rb'
+
+      def create_template
+        template(TEMPLATE_FILENAME, filename)
+      end
+
+      private
+
+      def filename
+        "onesie/templates/#{file_name}.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/onesie/templates/task.rb
+++ b/lib/generators/onesie/templates/task.rb
@@ -7,7 +7,7 @@ module Onesie
       manual_task enabled: false
 
       def run
-        <%= run_contents %>
+<%= run_contents.chomp.indent(8) %>
       end
     end
   end

--- a/lib/generators/onesie/templates/task.rb
+++ b/lib/generators/onesie/templates/task.rb
@@ -7,7 +7,7 @@ module Onesie
       manual_task enabled: false
 
       def run
-        # Write your Onesie Task here
+        <%= run_contents %>
       end
     end
   end

--- a/lib/generators/onesie/templates/template.rb
+++ b/lib/generators/onesie/templates/template.rb
@@ -1,0 +1,1 @@
+# Write the contents of Onesie::Tasks#run here!

--- a/lib/onesie.rb
+++ b/lib/onesie.rb
@@ -11,6 +11,7 @@ require_relative 'onesie/task'
 require_relative 'onesie/task_proxy'
 require_relative 'onesie/task_record'
 require_relative 'onesie/task_wrapper'
+require_relative 'onesie/template_reader'
 require_relative 'onesie/version'
 
 module Onesie

--- a/lib/onesie/tasks/onesie.rake
+++ b/lib/onesie/tasks/onesie.rake
@@ -8,12 +8,23 @@ namespace :onesie do
 
   # bundle exec rake onesie:new['MyTask']
   # bundle exec rake onesie:new['MyTask','high']
+  # bundle exec rake onesie:new['MyTask','high','ExampleTemplateName']
+  # bundle exec rake onesie:new['MyTask',,'ExampleTemplateName']
   desc 'Generates a new Onesie Task'
-  task :new, [:name, :priority] do |_t, args|
+  task :new, [:name, :priority, :template] do |_t, args|
     name = args.fetch(:name)
     priority = args.fetch(:priority, nil)
+    task_template = args.fetch(:template, nil)
 
-    Rails::Generators.invoke('onesie:task', [name, priority])
+    Rails::Generators.invoke('onesie:task', [name, priority, task_template])
+  end
+
+  # bundle exec rake onesie:new_template['ExampleTemplateName']
+  desc 'Generates a new Onesie Template'
+  task :new_template, [:filename] do |_t, args|
+    filename = args.fetch(:filename)
+
+    Rails::Generators.invoke('onesie:template', [filename])
   end
 
   # bundle exec rake onesie:rerun

--- a/lib/onesie/tasks/onesie.rake
+++ b/lib/onesie/tasks/onesie.rake
@@ -8,8 +8,8 @@ namespace :onesie do
 
   # bundle exec rake onesie:new['MyTask']
   # bundle exec rake onesie:new['MyTask','high']
-  # bundle exec rake onesie:new['MyTask','high','example_template_name']
-  # bundle exec rake onesie:new['MyTask',,'example_template_name']
+  # bundle exec rake onesie:new['MyTask','high','ExampleTemplateName']
+  # bundle exec rake onesie:new['MyTask',,'ExampleTemplateName']
   desc 'Generates a new Onesie Task'
   task :new, [:name, :priority, :template] do |_t, args|
     name = args.fetch(:name)

--- a/lib/onesie/tasks/onesie.rake
+++ b/lib/onesie/tasks/onesie.rake
@@ -8,8 +8,8 @@ namespace :onesie do
 
   # bundle exec rake onesie:new['MyTask']
   # bundle exec rake onesie:new['MyTask','high']
-  # bundle exec rake onesie:new['MyTask','high','ExampleTemplateName']
-  # bundle exec rake onesie:new['MyTask',,'ExampleTemplateName']
+  # bundle exec rake onesie:new['MyTask','high','example_template_name']
+  # bundle exec rake onesie:new['MyTask',,'example_template_name']
   desc 'Generates a new Onesie Task'
   task :new, [:name, :priority, :template] do |_t, args|
     name = args.fetch(:name)

--- a/lib/onesie/template_reader.rb
+++ b/lib/onesie/template_reader.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Onesie
+  # Responsible for loading custom template files
+  class TemplateReader
+    def self.read_template(path)
+      File.read(path)
+    end
+  end
+end

--- a/spec/onesie/generators/task_generator_spec.rb
+++ b/spec/onesie/generators/task_generator_spec.rb
@@ -5,14 +5,32 @@ require 'generators/onesie/task_generator'
 
 RSpec.describe Onesie::Generators::TaskGenerator, type: :generator do
   destination File.expand_path('../../../tmp', __dir__)
-  arguments %w[TestTask]
 
-  before do
-    prepare_destination
-    run_generator
+  context 'when only task name is specified' do
+    arguments %w[TestTask]
+
+    it 'creates a new task file with default template' do
+      allow_any_instance_of(described_class).to receive(:read_template).and_return(nil)
+
+      prepare_destination
+      run_generator
+
+      assert_migration 'onesie/tasks/test_task.rb', /class TestTask < Onesie::Task/
+      assert_migration 'onesie/tasks/test_task.rb', /# Write your Onesie Task here/
+    end
   end
 
-  it 'creates a new task file' do
-    assert_migration 'onesie/tasks/test_task.rb', /class TestTask < Onesie::Task/
+  context 'when template file is specified' do
+    arguments ['TestTask', nil, 'example_task']
+
+    it 'creates a new task file with the template file inside #run' do
+      allow_any_instance_of(described_class).to receive(:read_template).and_return('# sample custom content')
+
+      prepare_destination
+      run_generator
+
+      assert_migration 'onesie/tasks/test_task.rb', /class TestTask < Onesie::Task/
+      assert_migration 'onesie/tasks/test_task.rb', /# sample custom content/
+    end
   end
 end

--- a/spec/onesie/generators/task_generator_spec.rb
+++ b/spec/onesie/generators/task_generator_spec.rb
@@ -6,11 +6,15 @@ require 'generators/onesie/task_generator'
 RSpec.describe Onesie::Generators::TaskGenerator, type: :generator do
   destination File.expand_path('../../../tmp', __dir__)
 
+  before do
+    allow(Rails).to receive(:root).and_return(Pathname.new('.'))
+  end
+
   context 'when only task name is specified' do
     arguments %w[TestTask]
 
     it 'creates a new task file with default template' do
-      allow_any_instance_of(described_class).to receive(:read_template).and_return(nil)
+      allow(Onesie::TemplateReader).to receive(:read_template).and_return(nil)
 
       prepare_destination
       run_generator
@@ -24,7 +28,7 @@ RSpec.describe Onesie::Generators::TaskGenerator, type: :generator do
     arguments ['TestTask', nil, 'example_task']
 
     it 'creates a new task file with the template file inside #run' do
-      allow_any_instance_of(described_class).to receive(:read_template).and_return('# sample custom content')
+      allow(Onesie::TemplateReader).to receive(:read_template).and_return('# sample custom content')
 
       prepare_destination
       run_generator

--- a/spec/onesie/generators/template_generator_spec.rb
+++ b/spec/onesie/generators/template_generator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Onesie::Generators::TemplateGenerator, type: :generator do
 
   it 'creates a new template file' do
     path = 'tmp/onesie/templates/example_template.rb'
-    expect(File.exists?(path)).to eq(true)
+    expect(File.exist?(path)).to be(true)
 
     contents = File.read(path)
 

--- a/spec/onesie/generators/template_generator_spec.rb
+++ b/spec/onesie/generators/template_generator_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'generator_spec'
+require 'generators/onesie/template_generator'
+
+RSpec.describe Onesie::Generators::TemplateGenerator, type: :generator do
+  destination File.expand_path('../../../tmp', __dir__)
+  arguments %w[ExampleTemplate]
+
+  before do
+    prepare_destination
+    run_generator
+  end
+
+  it 'creates a new template file' do
+    path = 'tmp/onesie/templates/example_template.rb'
+    expect(File.exists?(path)).to eq(true)
+
+    contents = File.read(path)
+
+    expect(contents).to eq("# Write the contents of Onesie::Tasks#run here!\n")
+  end
+end


### PR DESCRIPTION
Fix https://github.com/timlkelly/onesie/issues/38

Will cherry-pick to a new PR targeting the upstream once this is merged

This allows consumers of Onesie to create templates using generators to quickly and reliably perform repeating Onesie tasks (like adding a new Permission, feature access, etc.), and allows documentation for performing these types of works to sit next to the code performing it.

Example usage:

```shell
$ bundle exec rake onesie:new_template['NewPermission']
      create  onesie/templates/new_permission.rb
```

Resulting file:

```ruby
# Write the contents of Onesie::Tasks#run here!

```

Can be updated to be:

```ruby
# This template serves as an "API" to easily create permissions with Onesies
# If there are any questions or concerns, please reach out to
# #guardians-of-the-velocity and reference the ticket number for help

# Select which actions are applicable for the new permissions
applicable_actions = %w[
  create
  read
  update
  delete
]

# Update the resource to be the resource we're adding (for ex: users)
resource = 'REPLACE ME'

# Select which applicable access contexts are for this permission
access_contexts = %w[
  Tenant
  Branch
  Group
]

# Select which role slugs we should add the new permission(s) to
roles_to_add_permissions_to = %w[
  admin
  internal
]

new_permission_slugs = applicable_actions.map do |action|
  puts "Creating #{action}:#{resource}".cyan
  Permission.where(
    resource: resource,
    access_contexts: access_contexts,
    action: action
  ).first_or_create!
end.map(&:slug)

roles = Role.where(slug: roles_to_add_permissions_to)

roles.each do |role|
  puts "Adding #{ permission_slugs} to #{role.slug}".cyan
  role.add_permission_slugs(new_permission_slugs)
end

```

Then, when we run:

```shell
$ bundle exec rake onesie:new['DEV-1234-add-new-foo-permission',,'NewPermission']
```

we get:

```ruby
# frozen_string_literal: true

module Onesie
  module Tasks
    class Dev1234AddNewFooPermission < Onesie::Task
      allowed_environments :all
      manual_task enabled: false

      def run
        # This template serves as an "API" to easily create permissions with Onesies
        # If there are any questions or concerns, please reach out to
        # #guardians-of-the-velocity and reference the ticket number for help

        # Select which actions are applicable for the new permissions
        applicable_actions = %w[
          create
          read
          update
          delete
        ]

        # Update the resource to be the resource we're adding (for ex: users)
        resource = 'REPLACE ME'

        # Select which applicable access contexts are for this permission
        access_contexts = %w[
          Tenant
          Branch
          Group
        ]

        # Select which role slugs we should add the new permission(s) to
        roles_to_add_permissions_to = %w[
          admin
          internal
        ]

        new_permission_slugs = applicable_actions.map do |action|
          puts "Creating #{action}:#{resource}".cyan
          Permission.where(
            resource: resource,
            access_contexts: access_contexts,
            action: action
          ).first_or_create!
        end.map(&:slug)

        roles = Role.where(slug: roles_to_add_permissions_to)

        roles.each do |role|
          puts "Adding #{ permission_slugs} to #{role.slug}".cyan
          role.add_permission_slugs(new_permission_slugs)
        end
      end
    end
  end
end
```
***

Please ensure the following:

- [x] The PR relates to _only_ one subject with a clear title and description
- [x] The changes are reflected in the CHANGELOG in the unreleased section
- [x] Reference the related issue if one exists, `Fix #[issue number]`
