### PR TITLE
update onesie documentation regarding templates

### DIFF
--- a/doc/how_to_guides/templates.md
+++ b/doc/how_to_guides/templates.md
@@ -25,21 +25,9 @@ code from the past and adapting it for the needs of today.
 ## Usage
 
 ### Finding templates to use
-If you suspect that the onesie you're about to write is essentially
-something we've done before (possibly several times), it can be worth
-checking if there's a more specific template already available. As of
-this writing, there are templates for establishing new environment
-configuration variables, creating a new feature access, and creating a
-new permission. You can find all the latest templates in the v2 repo,
-at
-[onesie/templates](https://github.com/watermelonexpress/benchprep-v2/tree/release_candidate/onesie/templates).
+Writing a onesie for a common use-case? Check to see if a template already exists in [onesie/templates](https://github.com/watermelonexpress/benchprep-v2/tree/release_candidate/onesie/templates), and if not, consider creating one!
 
 ### Creating a new template
-If you don't find an existing template that suits your needs, but
-still have the feeling that you're not the first to do something (and
-that you won't be the last), we hope you'll consider contributing a
-new template so that the next developer can have an easier time of it.
-_The time you save could be your own!_
 
 Generating a new template is similar to generating a onesie, which you
 should be familiar with from reading about onesie [usage](/usage.md).
@@ -59,26 +47,15 @@ shell, and when you open your new file, you should see a single line:
 
 ```
 
-As that comment says, you will now write the functional elements of
-the onesie. What you write will ultimately be placed (and indented)
+What you write will ultimately be placed (and indented)
 into the `def run` block of any onesie generated using your template,
 so don't repeat that line or any of the other elements around it.
 
-At this point, you can write the onesie contents as you normally
-would, including simply pasting in the code from the last time we did
-this type of task. Keep in mind, however, that you have the
-opportunity to make things simpler and clearer for the next person. It
-can be especially helpful to spell out what variables are needed at
+It can be especially helpful to spell out what variables are needed at
 the top of the file and include comments that provide explanations
-and/or examples. Properly cased placeholders can help, but always be
-sure it's clear what the template's next user will need to
-populate/replace. Review existing templates to get a sense of best
-practices.
+and/or examples. Make sure it's clear what the template's next user will 
+need to populate/replace.
 
-That said, don't worry about it too much and don't let theoretical
-perfection impede practical, incremental improvements! Any template is
-better than none, and the future developers (including you) can
-improve it further later if it's created in some form now.
 
 ### Creating a onesie using a template file
 Once you've found or created a template, use a command such as those

--- a/doc/how_to_guides/templates.md
+++ b/doc/how_to_guides/templates.md
@@ -51,10 +51,9 @@ and/or examples. Make sure it's clear what the template's next user
 will need to populate/replace.
 
 ### Creating a Onesie Using a Template File
-Once you've found or created a template, use a command such as those
-seen in [Onesie usage](/usage.md). Building on our example above, the
-corresponding usage would be something like this:
+To use a Onesie template, include the template filename as the third argument to `onesie:new`.
 
+#### Example
 ```bash
 bundle exec rake onesie:new['DEV-1234-add-new-foo-permission',,'NewPermission']
 

--- a/doc/how_to_guides/templates.md
+++ b/doc/how_to_guides/templates.md
@@ -9,31 +9,25 @@ created_at: 2024-11-21
 
 ## Overview
 As you should know from our documentation of their [usage](/usage.md),
-a onesie is already a sort of template. This guide will discuss the
-more specifically customized templates that allow us to define and
-easily re-use elements common among tasks of various generic types.
-
-## Why use templates?
-Templates generally consist of taking the same actions as previous
-onesies and performing them on new sets of arguments. They can
-make it easier for others to review your code by separating out what
-we've done before and what is new about the current effort. In a
-broader sense, they help us all avoid the tedium and error risk that
-can occur when digging up, identifying, and ultimately copying similar
-code from the past and adapting it for the needs of today.
+creating a Onesie already involves generating a basic template. This
+section will discuss the more specifically customized templates we
+create for easy re-use when we expect the core functions of a Onesie
+to be repeated in the future.
 
 ## Usage
 
-### Finding templates to use
-Writing a onesie for a common use-case? Check to see if a template already exists in [onesie/templates](https://github.com/watermelonexpress/benchprep-v2/tree/release_candidate/onesie/templates), and if not, consider creating one!
+### Finding Templates To Use
+Writing a Onesie for a common use-case? Check to see if a template
+already exists in
+[onesie/templates](https://github.com/watermelonexpress/benchprep-v2/tree/release_candidate/onesie/templates). If not, consider creating
+one!
 
-### Creating a new template
+### Creating a New Template
+Generating a new template file is similar to generating a Onesie.
+Review Onesie [usage](/usage.md) if unsure how and where to run this
+command.
 
-Generating a new template is similar to generating a onesie, which you
-should be familiar with from reading about onesie [usage](/usage.md).
-Insead of `onesie:new`, however, you'll use
-`onesie:new_template['Name']`. For example:
-
+#### Example
 ```bash
 bundle exec rake onesie:new_template['NewPermission']
 
@@ -47,19 +41,18 @@ shell, and when you open your new file, you should see a single line:
 
 ```
 
-What you write will ultimately be placed (and indented)
-into the `def run` block of any onesie generated using your template,
-so don't repeat that line or any of the other elements around it.
+What you write will ultimately be placed (and indented) into the
+`def run` block of any Onesie generated using your template, so don't
+repeat that line or any of the other elements around it.
 
 It can be especially helpful to spell out what variables are needed at
 the top of the file and include comments that provide explanations
-and/or examples. Make sure it's clear what the template's next user will 
-need to populate/replace.
+and/or examples. Make sure it's clear what the template's next user
+will need to populate/replace.
 
-
-### Creating a onesie using a template file
+### Creating a Onesie Using a Template File
 Once you've found or created a template, use a command such as those
-seen in [onesie usage](/usage.md). Building on our example above, the
+seen in [Onesie usage](/usage.md). Building on our example above, the
 corresponding usage would be something like this:
 
 ```bash

--- a/doc/how_to_guides/templates.md
+++ b/doc/how_to_guides/templates.md
@@ -1,0 +1,94 @@
+---
+title: Templates
+description:
+type: how_to_guide
+created_at: 2024-11-21
+---
+
+# Templates
+
+## Overview
+As you should know from our documentation their [usage](/usage.md),
+a onesie is already a sort of template. This guide will discuss the
+more specifically customized templates that allow us to define and
+easily re-use elements common among tasks of various generic types.
+
+## Why use templates?
+Templates generally consist of taking the same actions as previous
+onesies and performing them on new sets of arguments. They can
+make it easier for others to review your code by separating out what
+we've done before and what is new about the current effort. In a
+broader sense, they help us all avoid the tedium and error risk that
+can occur when digging up, identifying, and ultimately copying similar
+code from the past and adapting it for the needs of today.
+
+## Usage
+
+### Finding templates to use
+If you suspect that the onesie you're about to write is essentially
+something we've done before (possibly several times), it can be worth
+checking if there's a more specific template already available. As of
+this writing, there are templates for establishing new environment
+configuration variables, creating a new feature access, and creating a
+new permission. You can find all the latest templates in the v2 repo,
+at
+[onesie/templates](https://github.com/watermelonexpress/benchprep-v2/tree/release_candidate/onesie/templates).
+
+### Creating a new template
+If you don't find an existing template that suits your needs, but
+still have the feeling that you're not the first to do something (and
+that you won't be the last), we hope you'll consider contributing a
+new template so that the next developer can have an easier time of it.
+_The time you save could be your own!_
+
+Generating a new template is similar to generating a onesie, which you
+should be familiar with from reading about onesie [usage](/usage.md).
+Insead of `onesie:new`, however, you'll use
+`onesie:new_template['Name']`. For example:
+
+```bash
+bundle exec rake onesie:new_template['NewPermission']
+
+```
+
+This would print `create  onesie/templates/new_permission.rb` in your
+shell, and when you open your new file, you should see a single line:
+
+```bash
+# Write the contents of Onesie::Tasks#run here!
+
+```
+
+As that comment says, you will now write the functional elements of
+the onesie. What you write will ultimately be placed (and indented)
+into the `def run` block of any onesie generated using your template,
+so don't repeat that line or any of the other elements around it.
+
+At this point, you can write the onesie contents as you normally
+would, including simply pasting in the code from the last time we did
+this type of task. Keep in mind, however, that you have the
+opportunity to make things simpler and clearer for the next person. It
+can be especially helpful to spell out what variables are needed at
+the top of the file and include comments that provide explanations
+and/or examples. Properly cased placeholders can help, but always be
+sure it's clear what the template's next user will need to
+populate/replace. Review existing templates to get a sense of best
+practices.
+
+That said, don't worry about it too much and don't let theoretical
+perfection impede practical, incremental improvements! Any template is
+better than none, and the future developers (including you) can
+improve it further later if it's created in some form now.
+
+### Creating a onesie using a template file
+Once you've found or created a template, use a command such as those
+seen in [onesie usage](/usage.md). Building on our example above, the
+corresponding usage would be something like this:
+
+```bash
+bundle exec rake onesie:new['DEV-1234-add-new-foo-permission',,'NewPermission']
+
+```
+
+Now, rather than an empty `#run` method when you open the file, you
+will see the contents of the template. Huzzah!

--- a/doc/how_to_guides/templates.md
+++ b/doc/how_to_guides/templates.md
@@ -8,7 +8,7 @@ created_at: 2024-11-21
 # Templates
 
 ## Overview
-As you should know from our documentation their [usage](/usage.md),
+As you should know from our documentation of their [usage](/usage.md),
 a onesie is already a sort of template. This guide will discuss the
 more specifically customized templates that allow us to define and
 easily re-use elements common among tasks of various generic types.

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -99,8 +99,8 @@ be rake onesie:run_all                       # Run all unprocessed tasks
 During the development process, it may be useful to re-run a task.
 Use the `onesie:rerun` rake task without an argument to re-run the most recent task, or specify a filename to re-run a specific task.
 
-- Rerun the most recent task
-- Specify a task filename to rerun a specific task
+!!! Note
+    As stated in the [onesie overview](../explanations/overview.md), a onesie should be _idempotent_—infinitely re-runnable without generating any errors or redundant data.
 
 ### Examples
 ```bash

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -8,9 +8,9 @@ created_at: 2021-12-21
 # Usage
 
 ## Generate Onesie
-To create a new onesie for others to run, we ask that you use one of
-the following methods to generate the file (Rails generator or rake
-task) rather than creating the file yourself.
+To create a new Onesie for others to run, we ask that you use one of
+the following methods to generate the file (Rails generator or Rake
+Task) rather than creating the file yourself.
 
 ### Rails Generator
 
@@ -38,13 +38,13 @@ bundle exec rails generate onesie:task MyTask high # creates a high priority tas
 ```
 
 ### Rake
-The following commands should occur within a v2 shell
+The following commands should occur within a V2 shell
 (`dcc shell benchprep-v2`). For more information on setting up
 containers, please consult our
 [container setup guide](../infrastructure/how_to_guides/dev_containers/setup_guide.md).
 
-There are a variety of existing onesie [templates](/templates.md) that may 
-make your job easier. If you're writing a onesie for a common use case, take 
+There are a variety of existing Onesie [templates](/templates.md) that may
+make your job easier. If you're writing a Onesie for a common use case, take
 a look at existing templates, or consider writing your own template.
 
 #### API
@@ -62,16 +62,16 @@ bundle exec rake onesie:new['MyTask',,'SampleTemplate'] # creates a normal prior
 
 ```
 
-## Write your onesie task
-The generator will create a onesie file for you to adjust and
+## Write Your Onesie Task
+The generator will create a Onesie file for you to adjust and
 populate as needed. Your edits should occur mainly (if not
 exclusively) within the required `#run` method.
 
-For details about the task class and the class macros, see the
+For details about the Task class and the class macros, see the
 [Task](../explanations/task.md) document.
 
-## Run the onesie task
-There are three rake tasks to assist with running onesies.
+## Run the Onesie Task
+There are three Rake Tasks to assist with running Onesies:
 
 ```bash
 rake onesie:run[filename]              # Manually run a specific onesie task
@@ -81,7 +81,7 @@ rake onesie:run_tasks[priority_level]  # Run all tasks by priority level
 ```
 
 !!! Note
-    Manual tasks must be run individually with the `onesie:run` rake task. Running `onesie:describe` will helpfully generate the command needed to run each file as part of its listing of unprocessed tasks.
+    Manual Tasks must be run individually with the `onesie:run` Rake Task. Running `onesie:describe` will helpfully generate the command needed to run each file as part of its listing of unprocessed Tasks.
 
 ### Examples
 
@@ -93,11 +93,11 @@ be rake onesie:run_all                       # Run all unprocessed tasks
 ```
 
 ## Re-running a task
-During the development process, it may be useful to re-run a task.
-Use the `onesie:rerun` rake task without an argument to re-run the most recent task, or specify a filename to re-run a specific task.
+During the development process, it may be useful to re-run a Task.
+Use the `onesie:rerun` Rake Task without an argument to re-run the most recent Task, or specify a filename to re-run a specific Task.
 
 !!! Note
-    As stated in the [onesie overview](../explanations/overview.md), a onesie should be _idempotent_—infinitely re-runnable without generating any errors or redundant data.
+    As stated in the [Onesie overview](../explanations/overview.md), a Onesie should be _idempotent_—infinitely re-runnable without generating any errors or redundant data.
 
 ### Examples
 ```bash

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -7,9 +7,10 @@ created_at: 2021-12-21
 
 # Usage
 
-## Generate Onesie template
-The first step to adding a onesie is to create a new template task. This can
-be achieved with either the Rails generator or the Rake task
+## Generate Onesie
+To create a new onesie for others to run, we ask that you use one of
+the following methods to generate the file (Rails generator or rake
+task) rather than creating the file yourself.
 
 ### Rails Generator
 
@@ -33,13 +34,26 @@ Runtime options:
 ```bash
 bundle exec rails generate onesie:task MyTask      # creates a normal priority task
 bundle exec rails generate onesie:task MyTask high # creates a high priority task
+
 ```
 
 ### Rake
+The following commands should occur within a v2 shell
+(`dcc shell benchprep-v2`). For more information on setting up
+containers, please consult our
+[container setup guide](../infrastructure/how_to_guides/dev_containers/setup_guide.md).
+
+You may notice that some of these examples include an optional
+template name as their last argument. These meta-templates are
+created by developers here at BenchPrep to further facilitate the
+creation of common types of onesies. For more information on finding,
+using, and contributing onesie templates, please refer to our
+[templates](/templates.md) documentation.
 
 #### API
 ```bash
-rake onesie:new[name,priority,template]         # Generates a new Onesie Task
+rake onesie:new[name,priority,template]         # Generates a new onesie task
+
 ```
 
 #### Examples
@@ -47,50 +61,56 @@ rake onesie:new[name,priority,template]         # Generates a new Onesie Task
 ```bash
 bundle exec rake onesie:new['MyTask']        # creates a normal priority task
 bundle exec rake onesie:new['MyTask','high'] # creates a high priority task
-bundle exec rake onesie:new['MyTask','high','SampleTemplate'] # creates a high priority task using 'SampleTemplate'
+bundle exec rake onesie:new['MyTask',,'SampleTemplate'] # creates a normal priority task using 'SampleTemplate'
+
 ```
 
-## Write your Onesie Task
-The generator will create a onesie template file. The task must include the
-`#run` method. Add your code to the new task file.
+## Write your onesie task
+The generator will create a onesie file for you to adjust and
+populate as needed. Your edits should occur mainly (if not
+exclusively) within the required `#run` method.
 
-For details about the Task class and the class macros, see the
+For details about the task class and the class macros, see the
 [Task](../explanations/task.md) document.
 
-## Run the Onesie Task
-There are three Rake tasks to assist with running onesies.
+## Run the onesie task
+There are three rake tasks to assist with running onesies.
 
 ```bash
-rake onesie:run[filename]              # Manually run a specific Onesie Tasks
-rake onesie:run_all                    # Run all unprocessed Onesie Tasks
+rake onesie:run[filename]              # Manually run a specific onesie task
+rake onesie:run_all                    # Run all unprocessed onesie tasks
 rake onesie:run_tasks[priority_level]  # Run all tasks by priority level
+
 ```
 
 !!! Note
-    Manual tasks must be ran individually with the `onesie:run` rake task.
+    Manual tasks must be run individually with the `onesie:run` rake task. Running `onesie:describe` will helpfully generate the command needed to run each file as part of its listing of unprocessed tasks.
 
 ### Examples
 
 ```bash
 be rake onesie:run['20220105140152_my_task'] # Run 20220105140152_my_task.rb
 be rake onesie:run_tasks['high']             # Run all high priority tasks
-be rake onesie:run_tasks                     # Run all tasks without priority
+be rake onesie:run_all                     # Run all unprocessed tasks
+
 ```
 
-## Rerunning a Task
-During the development process, it may be useful to rerun a Onesie Task.
+## Rerunning a task
+During the development process, it may be useful to rerun a task.
 Use the `onesie:rerun` rake task to:
 
-- Rerun the most recent Task
-- Specify a Task filename to rerun a specific Task
+- Rerun the most recent task
+- Specify a task filename to rerun a specific task
 
 ### Examples
 ```bash
 bundle exec rake onesie:rerun                           # Reruns the last task
 bundle exec rake onesie:rerun['20220105140152_my_task'] # Reruns MyTask
+
 ```
 
 ## Describe
 ```bash
-rake onesies:describe                  # Prints a list of available onesies to run
+rake onesie:describe                  # Prints a list of available onesies to run
+
 ```

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -92,7 +92,7 @@ be rake onesie:run_all                       # Run all unprocessed Tasks
 
 ```
 
-## Re-running a task
+## Re-running a Task
 During the development process, it may be useful to re-run a Task.
 Use the `onesie:rerun` Rake Task without an argument to re-run the most recent Task, or specify a filename to re-run a specific Task.
 

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -32,8 +32,8 @@ Runtime options:
 
 #### Examples
 ```bash
-bundle exec rails generate onesie:task MyTask      # creates a normal priority task
-bundle exec rails generate onesie:task MyTask high # creates a high priority task
+bundle exec rails generate onesie:task MyTask      # creates a normal priority Task
+bundle exec rails generate onesie:task MyTask high # creates a high priority Task
 
 ```
 
@@ -49,16 +49,16 @@ a look at existing templates, or consider writing your own template.
 
 #### API
 ```bash
-rake onesie:new[name,priority,template]         # Generates a new onesie task
+rake onesie:new[name,priority,template]         # Generates a new Onesie Task
 
 ```
 
 #### Examples
 
 ```bash
-bundle exec rake onesie:new['MyTask']                   # creates a normal priority task
-bundle exec rake onesie:new['MyTask','high']            # creates a high priority task
-bundle exec rake onesie:new['MyTask',,'SampleTemplate'] # creates a normal priority task using 'SampleTemplate'
+bundle exec rake onesie:new['MyTask']                   # creates a normal priority Task
+bundle exec rake onesie:new['MyTask','high']            # creates a high priority Task
+bundle exec rake onesie:new['MyTask',,'SampleTemplate'] # creates a normal priority Task using 'SampleTemplate'
 
 ```
 
@@ -74,8 +74,8 @@ For details about the Task class and the class macros, see the
 There are three Rake Tasks to assist with running Onesies:
 
 ```bash
-rake onesie:run[filename]              # Manually run a specific onesie task
-rake onesie:run_all                    # Run all unprocessed onesie tasks
+rake onesie:run[filename]              # Manually run a specific Onesie Task
+rake onesie:run_all                    # Run all unprocessed Onesie Tasks
 rake onesie:run_tasks[priority_level]  # Run all tasks by priority level
 
 ```
@@ -87,8 +87,8 @@ rake onesie:run_tasks[priority_level]  # Run all tasks by priority level
 
 ```bash
 be rake onesie:run['20220105140152_my_task'] # Run 20220105140152_my_task.rb
-be rake onesie:run_tasks['high']             # Run all high-priority tasks
-be rake onesie:run_all                       # Run all unprocessed tasks
+be rake onesie:run_tasks['high']             # Run all high-priority Tasks
+be rake onesie:run_all                       # Run all unprocessed Tasks
 
 ```
 
@@ -101,13 +101,13 @@ Use the `onesie:rerun` Rake Task without an argument to re-run the most recent T
 
 ### Examples
 ```bash
-bundle exec rake onesie:rerun                           # Re-runs the last task
+bundle exec rake onesie:rerun                           # Re-runs the last Task
 bundle exec rake onesie:rerun['20220105140152_my_task'] # Re-runs MyTask
 
 ```
 
 ## Describe
 ```bash
-rake onesie:describe # Prints a list of onesies available to run, and the commands one would use to run each
+rake onesie:describe # Prints a list of Onesies available to run, and the commands to run each
 
 ```

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -43,12 +43,9 @@ The following commands should occur within a v2 shell
 containers, please consult our
 [container setup guide](../infrastructure/how_to_guides/dev_containers/setup_guide.md).
 
-You may notice that some of these examples include an optional
-template name as their last argument. These meta-templates are
-created by developers here at BenchPrep to further facilitate the
-creation of common types of onesies. For more information on finding,
-using, and contributing onesie templates, please refer to our
-[templates](/templates.md) documentation.
+There are a variety of existing onesie [templates](/templates.md) that may 
+make your job easier. If you're writing a onesie for a common use case, take 
+a look at existing templates, or consider writing your own template.
 
 #### API
 ```bash

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -59,8 +59,8 @@ rake onesie:new[name,priority,template]         # Generates a new onesie task
 #### Examples
 
 ```bash
-bundle exec rake onesie:new['MyTask']        # creates a normal priority task
-bundle exec rake onesie:new['MyTask','high'] # creates a high priority task
+bundle exec rake onesie:new['MyTask']                   # creates a normal priority task
+bundle exec rake onesie:new['MyTask','high']            # creates a high priority task
 bundle exec rake onesie:new['MyTask',,'SampleTemplate'] # creates a normal priority task using 'SampleTemplate'
 
 ```
@@ -90,8 +90,8 @@ rake onesie:run_tasks[priority_level]  # Run all tasks by priority level
 
 ```bash
 be rake onesie:run['20220105140152_my_task'] # Run 20220105140152_my_task.rb
-be rake onesie:run_tasks['high']             # Run all high priority tasks
-be rake onesie:run_all                     # Run all unprocessed tasks
+be rake onesie:run_tasks['high']             # Run all high-priority tasks
+be rake onesie:run_all                       # Run all unprocessed tasks
 
 ```
 
@@ -104,13 +104,13 @@ Use the `onesie:rerun` rake task to:
 
 ### Examples
 ```bash
-bundle exec rake onesie:rerun                           # Reruns the last task
-bundle exec rake onesie:rerun['20220105140152_my_task'] # Reruns MyTask
+bundle exec rake onesie:rerun                           # Re-runs the last task
+bundle exec rake onesie:rerun['20220105140152_my_task'] # Re-runs MyTask
 
 ```
 
 ## Describe
 ```bash
-rake onesie:describe                  # Prints a list of available onesies to run
+rake onesie:describe # Prints a list of onesies available to run, and the commands one would use to run each
 
 ```

--- a/doc/how_to_guides/usage.md
+++ b/doc/how_to_guides/usage.md
@@ -95,9 +95,9 @@ be rake onesie:run_all                       # Run all unprocessed tasks
 
 ```
 
-## Rerunning a task
-During the development process, it may be useful to rerun a task.
-Use the `onesie:rerun` rake task to:
+## Re-running a task
+During the development process, it may be useful to re-run a task.
+Use the `onesie:rerun` rake task without an argument to re-run the most recent task, or specify a filename to re-run a specific task.
 
 - Rerun the most recent task
 - Specify a task filename to rerun a specific task

--- a/onesie.gemspec
+++ b/onesie.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activerecord', '> 5'
-  spec.add_runtime_dependency 'railties',     '> 5'
-  spec.add_runtime_dependency 'rainbow',      '~> 3'
+  spec.add_dependency 'activerecord', '> 5'
+  spec.add_dependency 'railties',     '> 5'
+  spec.add_dependency 'rainbow',      '~> 3'
 end


### PR DESCRIPTION
Saw fit to update our internal docs with regard to the onesie templates we can now generate and use as of https://github.com/watermelonexpress/onesie/pull/4. I've included some edits related to grammar and consistency as well, but I'm fine separating or discarding those if anyone would prefer that. There's also a bit of editorializing and style guidance I'm not necessarily qualified to confer. I encourage those with more experience in these matters to further refine what I've put forth here.