### PR TITLE
[DACI-76] Log onesie run duration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
-require:
+require: rubocop-rspec
+
+plugins:
   - rubocop-performance
   - rubocop-rake
-  - rubocop-rspec
+  - rubocop-capybara
 
 AllCops:
   NewCops: enable

--- a/lib/onesie/task.rb
+++ b/lib/onesie/task.rb
@@ -35,9 +35,10 @@ module Onesie
       define_method(:manual_task?) { enabled }
     end
 
-    def initialize(name = self.class.name, version = nil)
+    def initialize(name = self.class.name, version = nil, disable_skip_task_message: false)
       @name = name
       @version = version
+      @disable_skip_task_message = disable_skip_task_message
     end
 
     private

--- a/lib/onesie/task_proxy.rb
+++ b/lib/onesie/task_proxy.rb
@@ -2,10 +2,13 @@
 
 module Onesie
   # TaskProxy is a stand in for the actual Task until the class is needed
-  TaskProxy = Struct.new(:name, :version, :file_path, :priority) do
-    def initialize(name, version, file_path, priority)
+  TaskProxy = Struct.new(:name, :version, :file_path, :priority, :disable_skip_task_message) do
+    attr_accessor :disable_skip_task_message
+
+    def initialize(name, version, file_path, priority, disable_skip_task_message: false)
       super
       @task = nil
+      @disable_skip_task_message = disable_skip_task_message
     end
 
     delegate :delete, to: :task_record
@@ -34,7 +37,7 @@ module Onesie
       require(File.expand_path(file_path))
       klass = "Onesie::Tasks::#{name}".constantize
       klass.class_eval { prepend Onesie::TaskWrapper }
-      klass.new(name, version)
+      klass.new(name, version, disable_skip_task_message: disable_skip_task_message)
     end
   end
 end

--- a/lib/onesie/task_wrapper.rb
+++ b/lib/onesie/task_wrapper.rb
@@ -8,15 +8,40 @@ module Onesie
   # and recording the Task
   # Prepend to the Task class prior to running
   module TaskWrapper
+    def log_start_message
+      @start_time = Time.current
+      puts "[Onesie] STARTED #{self.class.name} at #{@start_time}".magenta
+    end
+
+    def log_end_message
+      @end_time = Time.current
+      puts "[Onesie] FINISHED #{self.class.name} at #{@end_time} (took #{duration.round(2)}s)".green
+    end
+
+    def duration
+      @end_time - @start_time
+    end
+
+    def show_skipped_message
+      return if @disable_skip_task_message
+
+      notifier_message = "[Onesie] SKIPPED #{self.class.name} - already ran"
+      puts notifier_message.yellow
+      Onesie::Notifier.send_message(notifier_message) if defined?(Onesie::Notifier)
+    end
+
     def run(manual_override: false)
       return unless allowed_environment?
-      return if task_record_present?
+      return show_skipped_message if task_record_present?
       return if manual_task? && !manual_override
 
-      puts "Running #{name}...".magenta
+      log_start_message
       super()
       record_task
-      puts "Done running #{name}!".green
+      log_end_message
+      notifier_message = "[Onesie] #{self.class.name} STARTED at #{@start_time} and " \
+                         "FINISHED at #{@end_time} (took #{duration.round(2)}s)"
+      Onesie::Notifier.send_message(notifier_message) if defined?(Onesie::Notifier)
     end
   end
 end

--- a/onesie.gemspec
+++ b/onesie.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activerecord', '> 5'
-  spec.add_runtime_dependency 'railties',     '> 5'
-  spec.add_runtime_dependency 'rainbow',      '~> 3'
+  spec.add_dependency 'activerecord', '> 5'
+  spec.add_dependency 'railties',     '> 5'
+  spec.add_dependency 'rainbow',      '~> 3'
 end


### PR DESCRIPTION
Related items:
https://benchprep.atlassian.net/browse/DACI-76

Description:
Added code to display the start and end time of onesie tasks.